### PR TITLE
Have linker set RPATH, not RUNPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ if(${CMAKE_VERSION} VERSION_LESS 3.12)
 endif()
 project(hepemshow)
 
+# Have linker set RPATH, not RUNPATH
+SET(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags")
 
 #----------------------------------------------------------------------------
 # Find G4HepEm (sets G4HepEm_geant4_FOUND if a complete, Geant4 dependent build)


### PR DESCRIPTION
Running `./HepEmShow` gives an error
```
./HepEmShow: error while loading shared libraries: libg4HepEmData.so: cannot open shared object file: No such file or directory
``` 
on one of my systems running with Ubuntu 22.04, GCC 11.4.0, GLIBC 2.35, CMake 3.22.1. The problem can be solved by adding the G4HepEm lib install directory to `LD_LIBRARY_PATH`. On another system with Scientific Linux 7.9, GCC 13.1.0, GLIBC 2.17, 3.25.1, `HepEmShow` finds all the libraries out of the box.

I suppose that the Scientific Linux behavior is the desired one; otherwise please ignore this issue.

To understand the behavior on Ubuntu, I found it helpful the read [this StackOverflow post](https://stackoverflow.com/questions/52018092/how-to-set-rpath-and-runpath-with-gcc-ld). `chrpath -l` says that the G4HepEm lib install directory is 

- in the RPATH of the Scientific Linux executable but
- in the RUNPATH of the Ubuntu executable. 

According to `ldd`, on the Ubuntu system, `libg4HepEmDataJsonIO.so` is found while `libg4HepEmData.so` is not. Note that one of the differences between RUNPATH and RPATH is that the former is not searched for transitive dependencies. I guess that `./HepEmShow` depends on `libg4HepEmDataJsonIO.so` from G4HepEm, which can be found using either the RUNPATH (on Ubuntu) or the RPATH (on Scientific Linux); but then `libg4HepEmDataJsonIO.so` depends on `libg4HepEmData.so`, and this is not resolved on Ubuntu, because the RUNPATH and RPATH of `libg4HepEmDataJsonIO.so` are empty.

I can see the following ways to deal with the above error on Ubuntu:
- Do nothing, as the user should know to include the G4HepEm lib install directory in `LD_LIBRARY_PATH`.
- Use RPATH instead of RUNPATH when linking `HepEmShow`, by adding a line 
  ```cmake
  SET(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags")
  ``` 
  to the top-level CMakeLists.txt of HepEmShow.
- Set RUNPATHs of G4HepEm libraries as outlined in the [CMake wiki](https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling#always-full-rpath) by adding
  ```cmake
  set(CMAKE_SKIP_BUILD_RPATH FALSE)
  set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}")
  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
  ```
  to the top-level CMakeLists.txt of G4HepEm. 

This PR suggests the second option, but please feel free to close it if you prefer another option. I'm not too much of an expert in CMake and dynamic linking. Unfortunately I cannot tell how much the proposed change affects portability.